### PR TITLE
Implement support for commit comments

### DIFF
--- a/app/bettermail.go
+++ b/app/bettermail.go
@@ -219,7 +219,7 @@ func getRecipient() string {
 	if appengine.IsDevAppServer() {
 		return "mihai@quip.com"
 	}
-	return "shrey@quip.com"
+	return "eng+commits@quip.com"
 }
 
 func hookTestHarnessHandler(w http.ResponseWriter, r *http.Request) {

--- a/app/bettermail.go
+++ b/app/bettermail.go
@@ -174,13 +174,18 @@ func handleCommitCommentPayload(payload CommitCommentPayload, c context.Context)
 	commitShortSHA := commitSHA[:7]
 	commitURL := *payload.Repo.URL + "/commit/" + commitSHA
 
+	body := *payload.Comment.Body
+	if len(body) > 0 {
+	    body = renderMessageMarkdown(body, payload.Repo, c)
+	}
+
 	var data = map[string]interface{}{
 		"Payload":                  payload,
 		"Comment":                  payload.Comment,
 		"Sender":                   payload.Sender,
 		"Repo":                     payload.Repo,
 		"ShortSHA":                 commitShortSHA,
-		"Body":                     *payload.Comment.Body,
+		"Body":                     body,
 		"CommitURL":                commitURL,
 		"UpdatedDisplayDate":       safeFormattedDate(updatedDate.Format(DisplayDateFormat)),
 	}

--- a/app/config/styles.json
+++ b/app/config/styles.json
@@ -85,6 +85,38 @@
                     }
                 }
             }
+        },
+        "comment": {
+            "background": "#e6f1f6",
+            "border": "solid 1px #c5d5dd",
+            "border-radius": "3px",
+            "font-family": "Consolas,\"Liberation Mono\",Menlo,Courier,monospace",
+            "font-size": "11pt",
+            "margin-bottom": "1em",
+            "max-width": "900px",
+            "title": {
+                "margin": "10px",
+                "link": {
+                    "text-decoration": "none",
+                    "color": "#000"
+                }
+            },
+            "sender": {
+                "avatar": {
+                    "display": "inline-block",
+                    "overflow": "hidden",
+                    "line-height": "1",
+                    "vertical-align": "middle",
+                    "border-radius": "3px",
+                    "margin-right": "3px"
+                }
+            },
+            "body": {
+                "background": "white",
+                "margin": "0",
+                "padding": "10px",
+                "white-space": "pre-wrap"
+            }
         }
     },
     "footer": {

--- a/app/display.go
+++ b/app/display.go
@@ -102,10 +102,9 @@ const (
 	DisplayDateFullFormat = "Monday January 2 3:04pm"
 )
 
-func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookRepository, location *time.Location, c appengine.Context) DisplayCommit {
-	messagePieces := strings.SplitN(*commit.Message, "\n", 2)
+func getTitleAndMessageFromCommitMessage(message string) (string, string) {
+	messagePieces := strings.SplitN(message, "\n", 2)
 	title := messagePieces[0]
-	message := ""
 	if len(messagePieces) == 2 {
 		message = messagePieces[1]
 	}
@@ -119,7 +118,11 @@ func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookR
 		}
 		title = title[:80] + "…"
 	}
+    return title, message
+}
 
+func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookRepository, location *time.Location, c appengine.Context) DisplayCommit {
+    title, message := getTitleAndMessageFromCommitMessage(*commit.Message)
 	messageHtml := ""
 	if len(message) > 0 {
 		// The Markdown endpoint does not escape <, >, etc. so we need to do it

--- a/app/display.go
+++ b/app/display.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"appengine"
-	"appengine/urlfetch"
-
 	"github.com/google/go-github/github"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/urlfetch"
+	"google.golang.org/appengine/log"
 )
 
 func safeFormattedDate(date string) string {
@@ -118,11 +118,11 @@ func getTitleAndMessageFromCommitMessage(message string) (string, string) {
 		}
 		title = title[:80] + "…"
 	}
-    return title, message
+	return title, message
 }
 
-func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookRepository, location *time.Location, c appengine.Context) DisplayCommit {
-    title, message := getTitleAndMessageFromCommitMessage(*commit.Message)
+func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookRepository, location *time.Location, c context.Context) DisplayCommit {
+	title, message := getTitleAndMessageFromCommitMessage(*commit.Message)
 	messageHtml := ""
 	if len(message) > 0 {
 		// The Markdown endpoint does not escape <, >, etc. so we need to do it
@@ -134,7 +134,7 @@ func newDisplayCommit(commit *WebHookCommit, sender *github.User, repo *WebHookR
 			Context: *repo.FullName,
 		})
 		if err != nil {
-			c.Warningf("Could not do markdown rendering, got error %s", err)
+			log.Warningf(c, "Could not do markdown rendering, got error %s", err)
 			messageHtml = fmt.Sprintf("<div style=\"%s\">%s</div>",
 				getStyle("commit.message.block"), messageHtml)
 		} else {

--- a/app/payloads.go
+++ b/app/payloads.go
@@ -21,6 +21,13 @@ type PushPayload struct {
 	Repo       *WebHookRepository `json:"repository,omitempty"`
 }
 
+type CommitCommentPayload struct {
+	Action     *string               `json:"action,omitempty"`
+	Comment    *WebHookCommitComment `json:"comment,omitempty"`
+	Repo       *WebHookRepository    `json:"repository,omitempty"`
+	Sender     *github.User          `json:"sender,omitempty"`
+}
+
 // WebHookCommit represents the commit variant we receive from GitHub in a
 // WebHookPayload.
 type WebHookCommit struct {
@@ -34,6 +41,20 @@ type WebHookCommit struct {
 	Modified  []string              `json:"modified,omitempty"`
 	Removed   []string              `json:"removed,omitempty"`
 	Timestamp *time.Time            `json:"timestamp,omitempty"`
+}
+
+type WebHookCommitComment struct {
+	ID        *int                  `json:"id,omitempty"`
+	User      *github.User          `json:"user,omitempty"`
+	URL       *string               `json:"url,omitempty"`
+	HTML_URL  *string               `json:"html_url,omitempty"`
+	CommitID  *string               `json:"commit_id,omitempty"`
+	Body      *string               `json:"body,omitempty"`
+	CreatedAt *time.Time            `json:"created_at,omitempty"`
+	UpdatedAt *time.Time            `json:"updated_at,omitempty"`
+	Position  *int                  `json:"position,omitempty"`
+	Line      *int                  `json:"line,omitempty"`
+	Path      *string               `json:"path,omitempty"`
 }
 
 type WebHookRepository struct {
@@ -117,4 +138,10 @@ type WebHookRepository struct {
 	TagsURL          *string `json:"tags_url,omitempty"`
 	TreesURL         *string `json:"trees_url,omitempty"`
 	TeamsURL         *string `json:"teams_url,omitempty"`
+}
+
+// Represents the payload received from the /commits API call 
+type ApiCommit struct {
+	Commit           *WebHookCommit    `json:"commit,omitempty"`
+	HTML_URL         *string           `json:"html_url,omitempty"`
 }

--- a/app/templates/commit-comment.html
+++ b/app/templates/commit-comment.html
@@ -1,7 +1,7 @@
 <div style={{style "proportional" "commit.comment" }}>
   <div style={{style "commit.comment.title"}}>
     <a href="https://github.com/{{.Sender.Login}}"
-       title="{{.Sender.Name}}"
+       title="{{.Sender.Login}}"
        style="{{style "link"}}">
       <img src="{{.Sender.AvatarURL}}"
            width="24"

--- a/app/templates/commit-comment.html
+++ b/app/templates/commit-comment.html
@@ -1,0 +1,19 @@
+<div style={{style "proportional" "commit.comment" }}>
+  <div style={{style "commit.comment.title"}}>
+    <a href="https://github.com/{{.Sender.Login}}"
+       title="{{.Sender.Name}}"
+       style="{{style "link"}}">
+      <img src="{{.Sender.AvatarURL}}"
+           width="24"
+           height="24"
+           border="0"
+          style="{{style "commit.comment.sender.avatar"}}"/>{{.Payload.Sender.Login}}
+    </a>
+    commented on
+    <a href="{{.CommitURL}}" style="{{style "link"}}">{{.ShortSHA}}</a> at <a href="{{.Comment.HTML_URL}}" style="{{style "link"}}">{{.Comment.Path}}#L{{.Comment.Line}}</a>:
+  </div>
+  <div style="{{style "commit.comment.body"}}">{{html .Body}}</div>
+</div>
+<div style={{style "proportional" "footer"}}>
+    Comment {{.Payload.Action}} at <span style="{{style "date"}}">{{.UpdatedDisplayDate}}</span>.
+</div>

--- a/app/templates/hook-test-harness.html
+++ b/app/templates/hook-test-harness.html
@@ -31,7 +31,7 @@
         Event Type:
         <select name="event_type">
           <option value="push">push</option>
-          <option value="commit-comment">commit comment</option>
+          <option value="commit_comment">commit comment</option>
         </select>
       </label>
     </div>

--- a/app/templates/hook-test-harness.html
+++ b/app/templates/hook-test-harness.html
@@ -31,6 +31,7 @@
         Event Type:
         <select name="event_type">
           <option value="push">push</option>
+          <option value="commit-comment">commit comment</option>
         </select>
       </label>
     </div>


### PR DESCRIPTION
Since the webhook payload doesn't provide the commit title, which we use
for the push message subject lines, I had to add an API call to fetch
the title.

This _should_ cause gmail to thread commits with comments properly, but
I wasn't able to get sendmail to actually send emails to myself to test
it out.

Still need to split the push email into one email per commit to make
threading perfect.

This is how the e-mail looks in the test harness:
![image](https://cloud.githubusercontent.com/assets/541603/16479319/5e959b82-3e54-11e6-9999-e19b008c113b.png)
